### PR TITLE
get mysql build working on OS X when LC_CTYPE isn't set to C

### DIFF
--- a/ups/eupspkg.cfg.sh
+++ b/ups/eupspkg.cfg.sh
@@ -2,6 +2,7 @@
 
 # Breaks on Darwin w/o this
 export LANG=C
+export LC_CTYPE=C
 
 prep()
 {


### PR DESCRIPTION
On some recent Mac OS X's (possibly associated with macports, but possibly not), `LC_CTYPE=en_US.UTF-8`, but that makes sed fail while installing mysql.  setting the LC_CTYPE explicitly to `C` solves this.  (see http://bugs.mysql.com/bug.php?id=66811 for more on this)
