### PR TITLE
Added LC_ALL fix for build

### DIFF
--- a/ups/eupspkg.cfg.sh
+++ b/ups/eupspkg.cfg.sh
@@ -3,6 +3,7 @@
 # Breaks on Darwin w/o this
 export LANG=C
 export LC_CTYPE=C
+export LC_ALL=C
 
 prep()
 {


### PR DESCRIPTION
As discussed in person with @mjuric @r-owen  @SimonKrughoff, the fix in #1 turns out to be incomplete because LC_ALL overrides LC_CTYPE if it is set.  So this just adds LC_ALL.

Also note that this is particularly important because of http://astropy.readthedocs.org/en/latest/known_issues.html#locale-errors-in-macos-x-and-linux - do build astropy on OS X, sometime the LC_CTYPE/LC_ALL/LANG has to be set to  `en_US.UTF-8`.  So many astropy users might get hit by this.
